### PR TITLE
This fixes (IIRC) the dynamics of the pod under reverse gravity - i.e. it makes reverse gravity affect the pod too.

### DIFF
--- a/thrust/classShip.js
+++ b/thrust/classShip.js
@@ -103,7 +103,7 @@ function Ship() {
 
         // calculate new pod position 
         oGame.oPod.iPositionX += oGame.oPod.iVectorX;
-        oGame.oPod.iPositionY += oGame.oPod.iVectorY + 0.1;
+        oGame.oPod.iPositionY += oGame.oPod.iVectorY + oGame.oLevel.iGravity;
 
         // calculate push/pull of the rod
         var iDeltaX = (oGame.oPod.iPositionX - this.iPositionX);


### PR DESCRIPTION
I updated classShip.js to apply game gravity to pod rather than the fixed 0.1 value, so that reverse gravity acts correctly on the pod. It's been a while since I played the original, but IIRC correctly, this brings the dynamics closer to the original game play in the reverse gravity levels. 

I appreciate this is slightly more than "reversing" gravity on the pod, as the gravity levels throughout the game are slightly different to the previous 0.1 fixed value, however my feeling was that the pod felt slightly heavier in the original too, so I figured this simple fix would address that too.

Many thanks for making this excellent recreation available! I hope I'm not mis-remembering the original in suggesting this quick fix. 